### PR TITLE
fix: Add 'openid' to allowed scopes for 'client' in auth-server

### DIFF
--- a/authorization-server/src/main/java/io/github/akumosstl/auth/security/SecurityConfig.java
+++ b/authorization-server/src/main/java/io/github/akumosstl/auth/security/SecurityConfig.java
@@ -134,6 +134,7 @@ public class SecurityConfig {
                 .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 .redirectUri("http://localhost/callback") // Added placeholder redirect URI
                 .scope("message.read")
+                .scope("openid") // Added openid scope
                 .tokenSettings(TokenSettings.builder()
                         .accessTokenTimeToLive(Duration.ofHours(1))
                         .build())


### PR DESCRIPTION
Modifies SecurityConfig.java in the authorization-server to include 'openid' as an allowed scope for the RegisteredClient with clientId 'client'. The client's scopes are now 'message.read' and 'openid'.

This change is made to accommodate the client script which persistently requests 'openid message.read', thereby resolving the recurring '[invalid_scope]' error by making the server configuration more permissive for this specific client and these scopes.