### PR TITLE
feat: Add getToken_noscopes.bat for diagnostics

### DIFF
--- a/_script/getToken_noscopes.bat
+++ b/_script/getToken_noscopes.bat
@@ -1,0 +1,15 @@
+@echo off
+echo Requesting token with NO scopes (client_credentials grant)...
+echo Target: http://localhost:9000/oauth2/token
+echo Client ID: client, Client Secret: secret
+echo Grant Type: client_credentials
+echo.
+
+curl -k -X POST http://localhost:9000/oauth2/token ^
+  -H "Authorization: Basic Y2xpZW50OnNlY3JldA==" ^
+  -H "Content-Type: application/x-www-form-urlencoded" ^
+  -d "grant_type=client_credentials"
+
+echo.
+echo.
+echo Script finished.

--- a/authorization-server/src/main/java/io/github/akumosstl/auth/security/SecurityConfig.java
+++ b/authorization-server/src/main/java/io/github/akumosstl/auth/security/SecurityConfig.java
@@ -133,8 +133,7 @@ public class SecurityConfig {
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
                 .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 .redirectUri("http://localhost/callback") // Added placeholder redirect URI
-                .scope("message.read")
-                .scope("openid") // Added openid scope
+                // All .scope() calls removed for this client for diagnostic purposes
                 .tokenSettings(TokenSettings.builder()
                         .accessTokenTimeToLive(Duration.ofHours(1))
                         .build())


### PR DESCRIPTION
Adds a new script _script/getToken_noscopes.bat that performs a client credentials grant without requesting any scopes. This was used for diagnosing issues with scope validation.

The related diagnostic change to SecurityConfig.java (removing scopes from the client registration) will be reverted/updated in a subsequent commit when re-adding specific scopes for the client.